### PR TITLE
Making docs pretty

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,20 @@
 site_name: My Aviation Project
 theme:
   name: material
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      primary: light blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 
 nav:
   - Home: "index.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,18 +3,24 @@ theme:
   name: material
   palette:
     # Palette toggle for light mode
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       primary: light blue
       toggle:
-        icon: material/brightness-7
+        icon: material/toggle-switch
         name: Switch to dark mode
 
     # Palette toggle for dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       primary: indigo
       toggle:
-        icon: material/brightness-4
+        icon: material/toggle-switch-off-outline
         name: Switch to light mode
+  features:
+    - navigation.tracking
+    - navigation.expand
+    - toc.integrate
 
 nav:
   - Home: "index.md"


### PR DESCRIPTION
Added some additional mkdocs material features such as a toggle for light and dark mode, that also changes the primary colour, and some navigation updates: tracking what page you are on and displaying the table of contents along with the naviation. 
This can all be found here: [mkdoccs material references](https://squidfunk.github.io/mkdocs-material/reference/)
Note that not all features are compatible with the check-yaml pre-hook that I have set up.

