### PR TITLE
reconfigured testing to incorporate new days_per_year

### DIFF
--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -1,16 +1,14 @@
 """Analysis to determine the number of passengers per day."""
 
 import camia_engine as engine
-from camia_model.units import day, year
+from camia_model.units import year
 
 import aviation
 from aviation.units import passenger
 
-days_per_year = 365.25 * day / year
 passengers_per_year = 2000000.0 * passenger / year
 
 inputs = {
-    "days_per_year": days_per_year,
     "passengers_per_year": passengers_per_year,
 }
 output = "passengers_per_day"

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -6,14 +6,12 @@ from camia_model.units import day, year
 import aviation
 from aviation.units import aircraft, journey, passenger
 
-days_per_year = 366.0 * day / year
 passengers_per_year = 5_000_000_000.0 * passenger / year
 seats_per_aircraft = 180.0 * passenger / aircraft
 flight_per_aircraft_per_day = 2.0 * journey / (aircraft * day)
 
 inputs = {
     "passengers_per_year": passengers_per_year,
-    "days_per_year": days_per_year,
     "seats_per_aircraft": seats_per_aircraft,
     "flight_per_aircraft_per_day": flight_per_aircraft_per_day,
 }
@@ -22,7 +20,7 @@ output = "required_global_fleet"
 systems_model = engine.SystemsModel(aviation.transforms)
 required_global_fleet = systems_model.evaluate(inputs, output)
 
-passengers_per_day = aviation.passengers_per_day(passengers_per_year, days_per_year)
+passengers_per_day = aviation.passengers_per_day(passengers_per_year)
 required_global_fleet = aviation.required_global_fleet(
     passengers_per_day, seats_per_aircraft, flight_per_aircraft_per_day
 )

--- a/src/aviation/aviation.py
+++ b/src/aviation/aviation.py
@@ -11,7 +11,6 @@ from aviation.units import aircraft, journey, passenger
 @model.transform
 def passengers_per_day(
     passengers_per_year: typing.Annotated[Quantity, passenger / year],
-    days_per_year: typing.Annotated[Quantity, day / year],
 ) -> typing.Annotated[Quantity, passenger / day]:
     """The number of passengers per day globally.
 
@@ -20,7 +19,7 @@ def passengers_per_day(
         days_per_year: Number of days in that specific year.
 
     """
-    return passengers_per_year / days_per_year
+    return passengers_per_year.convert_to(passenger / day)
 
 
 @model.transform

--- a/tests/test_aviation.py
+++ b/tests/test_aviation.py
@@ -9,32 +9,30 @@ from aviation.units import aircraft, journey, passenger
 
 
 @pytest.mark.parametrize(
-    ("passengers_per_year", "days_per_year", "expected_passengers_per_day"),
+    ("passengers_per_year", "expected_passengers_per_day"),
     (
-        (365_000_000.0 * passenger / year, 365.0 * day / year, 1_000_000.0 * passenger / day),
-        (732_000_000.0 * passenger / year, 366.0 * day / year, 2_000_000.0 * passenger / day),
+        (365_000_000.0 * passenger / year, 999_315.0 * passenger / day),
+        (732_000_000.0 * passenger / year, 2_004_106.0 * passenger / day),
     ),
 )
 def test_passengers_per_day(
     passengers_per_year: typing.Annotated[Quantity, passenger / year],
-    days_per_year: typing.Annotated[Quantity, day / year],
     expected_passengers_per_day: typing.Annotated[Quantity, passenger / day],
 ) -> None:
-    assert passengers_per_day(passengers_per_year, days_per_year) == pytest_camia.approx(
+    assert passengers_per_day(passengers_per_year) == pytest_camia.approx(
         expected_passengers_per_day, atol=1.0
     )
 
 
 def test_required_global_fleet() -> None:
-    days_per_year = 365.25 * day / year
     passengers_per_year = 5_000_000_000.0 * passenger / year
     seats_per_aircraft = 180.0 * passenger / aircraft
     flight_per_aircraft_per_day = 2.0 * journey / (aircraft * day)
 
-    expected_required_global_fleet = 38025.0 * aircraft
+    expected_required_global_fleet = 38_025.0 * aircraft
 
     result = required_global_fleet(
-        passengers_per_day(passengers_per_year, days_per_year),
+        passengers_per_day(passengers_per_year),
         seats_per_aircraft,
         flight_per_aircraft_per_day,
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -24,7 +24,6 @@ def systems_model() -> engine.SystemsModel:
         (
             {
                 "passengers_per_year": 5_000_000_000.0 * passenger / year,
-                "days_per_year": 365.25 * day / year,
             },
             "passengers_per_day",
             13689253.94 * passenger / day,
@@ -36,17 +35,16 @@ def systems_model() -> engine.SystemsModel:
                 "flight_per_aircraft_per_day": 2.0 * journey / (aircraft * day),
             },
             "required_global_fleet",
-            37947.78 * aircraft,
+            37947.0 * aircraft,
         ),
         (
             {
-                "days_per_year": 366.0 * day / year,
                 "passengers_per_year": 5_000_000_000.0 * passenger / year,
                 "seats_per_aircraft": 180.0 * passenger / aircraft,
                 "flight_per_aircraft_per_day": 2.0 * journey / (aircraft * day),
             },
             "required_global_fleet",
-            37947.78 * aircraft,
+            38025.0 * aircraft,
         ),
     ),
 )


### PR DESCRIPTION
This PR:
- removes days_per_year as a input from all transforms and tests
- uses camia_model's convert_to function to convert year to days
- changed some tests to validate a new number of days per year which is now set to 365.25