### PR TITLE
Demand model module and testing

### DIFF
--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,4 +1,4 @@
-"""Analysis to determine the required global fleet."""
+"""Analysis to determine the required global fleet estimated using aviation module."""
 
 import camia_engine as engine
 from camia_model.units import day, year

--- a/src/aviation/__init__.py
+++ b/src/aviation/__init__.py
@@ -2,10 +2,28 @@
 
 Modules:
     aviation: Modelling global fleet using average number of passengers and aircraft data.
+    demand: Modelling growth for global demand for aviation.
 """
 
-__all__ = ("passengers_per_day", "required_global_fleet", "transforms")
+__all__ = (
+    "DemandGrowthModel",
+    "passengers_per_day",
+    "required_global_fleet",
+    "transforms",
+)
 
 from aviation.aviation import passengers_per_day, required_global_fleet
+from aviation.demand import (
+    DemandGrowthModel,
+    demand_growth_model,
+    demand_growth_rate,
+    passengers_per_year,
+)
 
-transforms = (passengers_per_day, required_global_fleet)
+transforms = (
+    demand_growth_model,
+    passengers_per_day,
+    required_global_fleet,
+    demand_growth_rate,
+    passengers_per_year,
+)

--- a/src/aviation/demand.py
+++ b/src/aviation/demand.py
@@ -1,0 +1,66 @@
+"""Growth in global aviation."""
+
+__all__ = (
+    "DemandGrowthModel",
+    "demand_growth_model",
+    "passengers_per_year",
+)
+
+import enum
+import typing
+
+import camia_model as model
+from camia_model.units import DIMENSIONLESS, Quantity, percent, year
+
+from aviation.units import passenger
+
+PASSENGER_PER_YEAR_2025 = 5_000_000.0 * passenger / year
+
+
+@enum.unique
+class DemandGrowthModel(enum.Enum):
+    """Different models used for demand growth."""
+
+    EXPONENTIAL = enum.auto()
+    LINEAR = enum.auto()
+    CONSTANT = enum.auto()
+
+
+@model.transform
+def demand_growth_model() -> DemandGrowthModel:
+    """The default demand growth model is exponenital."""
+    return DemandGrowthModel.EXPONENTIAL
+
+
+@model.transform
+def demand_growth_rate() -> typing.Annotated[Quantity, percent / year]:
+    """Expected growth rate for number of passengers starting from 2025."""
+    return 4.0 * percent / year
+
+
+@model.transform.switch(demand_growth_model=DemandGrowthModel.LINEAR)
+def passengers_per_year(
+    modeling_year: int, demand_growth_rate: typing.Annotated[Quantity, percent / year]
+) -> typing.Annotated[Quantity, passenger / year]:
+    """The number of passengers per year globally assuming linear growth rate."""
+    growth_factor = (100.0 * percent + demand_growth_rate * 1.0 * year).convert_to(DIMENSIONLESS)
+    return PASSENGER_PER_YEAR_2025 + PASSENGER_PER_YEAR_2025 * (
+        float(modeling_year - 2025) * growth_factor
+    )
+
+
+@model.transform.switch(demand_growth_model=DemandGrowthModel.EXPONENTIAL)  # type: ignore[no-redef]
+def passengers_per_year(  # noqa: F811
+    modeling_year: int, demand_growth_rate: typing.Annotated[Quantity, percent / year]
+) -> typing.Annotated[Quantity, passenger / year]:
+    """The number of passengers per year globally estimated assuming exponential growth rate."""
+    growth_factor = (100.0 * percent + demand_growth_rate * 1.0 * year).convert_to(DIMENSIONLESS)
+    return (PASSENGER_PER_YEAR_2025 * growth_factor ** (modeling_year - 2025)).cast_to(
+        passenger / year
+    )
+
+
+@model.transform.switch(demand_growth_model=DemandGrowthModel.CONSTANT)  # type: ignore[no-redef]
+def passengers_per_year() -> typing.Annotated[Quantity, passenger / year]:  # noqa: F811
+    """The number of passengers per year globally estimated assuming constant growth rate."""
+    return PASSENGER_PER_YEAR_2025.cast_to(passenger / year)

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -1,0 +1,42 @@
+import typing
+
+import pytest
+import pytest_camia
+from camia_model.units import Quantity, percent, year
+
+from aviation.demand import (
+    DemandGrowthModel,
+    demand_growth_rate,
+    passengers_per_year,
+)
+from aviation.units import passenger
+
+
+def test_demand_growth_rate() -> None:
+    assert demand_growth_rate() == 4.0 * percent / year
+
+
+@pytest.mark.parametrize(
+    ("demand_growth_model", "modeling_year", "demand_growth_rate", "expected_passengers_per_year"),
+    (
+        (DemandGrowthModel.EXPONENTIAL, 2025, 4.0 * percent / year, 5_000_000.0 * passenger / year),
+        (
+            DemandGrowthModel.EXPONENTIAL,
+            2025,
+            10.0 * percent / year,
+            5_000_000.0 * passenger / year,
+        ),
+        (DemandGrowthModel.LINEAR, 2025, 10.0 * percent / year, 5_000_000.0 * passenger / year),
+        # (DemandGrowthModel.EXPONENTIAL, 2026, 4.0 * percent / year, 5_000_000.0 * passenger / year),
+    ),
+)
+def test_passengers_per_year(
+    demand_growth_model: DemandGrowthModel,
+    modeling_year: int,
+    demand_growth_rate: typing.Annotated[Quantity, percent / year],
+    expected_passengers_per_year: typing.Annotated[Quantity, passenger / year],
+) -> None:
+    with passengers_per_year.context(demand_growth_model=demand_growth_model):
+        assert passengers_per_year(modeling_year, demand_growth_rate) == pytest_camia.approx(
+            expected_passengers_per_year, atol=1.0
+        )


### PR DESCRIPTION
This PR:
- Created a new module `demand.py` 
- Incorporated 3 demand models with a switch transform to manage between constant, linear and exponential growth predictions
- Created some basic testing for `demand.py ` in `testing_demand.py` but more to come (added issue)
- Updated various doctrings and the `__init__.py` file to relfect these changes